### PR TITLE
Adding threadlocks around the read/write of the LRUCache

### DIFF
--- a/lib/pyld/__init__.py
+++ b/lib/pyld/__init__.py
@@ -1,5 +1,9 @@
 """ The PyLD module is used to process JSON-LD. """
+
 from . import jsonld
 from .context_resolver import ContextResolver
 
-__all__ = ['jsonld', 'ContextResolver']
+
+__version__ = "2.0.5"
+
+__all__ = ["jsonld", "ContextResolver"]

--- a/lib/pyld/resolved_context.py
+++ b/lib/pyld/resolved_context.py
@@ -9,13 +9,16 @@ Representation for a resolved Context.
 """
 
 from cachetools import LRUCache
+import threading
 
 MAX_ACTIVE_CONTEXTS = 10
+
 
 class ResolvedContext:
     """
     A cached contex document, with a cache indexed by referencing active context.
     """
+
     def __init__(self, document):
         """
         Creates a ResolvedContext with caching for processed contexts
@@ -24,15 +27,18 @@ class ResolvedContext:
         # processor-specific RDF parsers
         self.document = document
         self.cache = LRUCache(maxsize=MAX_ACTIVE_CONTEXTS)
+        self.lock = threading.Lock()
 
     def get_processed(self, active_ctx):
         """
         Returns any processed context for this resolved context relative to an active context.
         """
-        return self.cache.get(active_ctx['_uuid'])
+        with self.lock:
+            return self.cache.get(active_ctx["_uuid"])
 
     def set_processed(self, active_ctx, processed_ctx):
         """
         Sets any processed context for this resolved context relative to an active context.
         """
-        self.cache[active_ctx['_uuid']] = processed_ctx
+        with self.lock:
+            self.cache[active_ctx["_uuid"]] = processed_ctx

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools"]
+requires = ["setuptools>=61.0"]
 build-backend = "setuptools.build_meta"
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ include = [
 [project]
 name = "PyLD"
 dynamic = ["version", "readme"]
-requires-python = ">= 3.13"
+requires-python = ">= 3.10"
 description="Python implementation of the JSON-LD API"
 authors = [
 {name = "Digital Bazaar", email="support@digitalbazaar.com"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,52 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
+
+
+[tool.black]
+line-length = 88
+target-version = ['py310']
+include = '\.pyi?$'
+extend-exclude = '''
+/(
+  # The following are specific to Black, you probably don't want those.
+  | blib2to3
+  | tests/data
+  | profiling
+)/
+'''
+
+[tool.setuptools.dynamic]
+version = {attr = "pyld.__version__"}
+readme = {file = ["README.rst", "USAGE.rst"]}
+
+[tool.setuptools.packages.find]
+where = ["lib"]
+include = [
+        "c14n",
+        "pyld",
+        "pyld.documentloader"
+]
+
+[project]
+name = "PyLD"
+dynamic = ["version", "readme"]
+requires-python = ">= 3.13"
+description="Python implementation of the JSON-LD API"
+authors = [
+{name = "Digital Bazaar", email="support@digitalbazaar.com"}
+]
+urls = {github = "https://github.com/digitalbazaar/pyld"}
+license = {text = "BSD 3-Clause license"}
+dependencies=[
+    "cachetools",
+    "frozendict",
+    "lxml"
+]
+
+
+[project.optional-dependencies]
+requests = ["requests"]
+aiohttp = ["aiohttp"]
+cachetools = ["cachetools"]
+frozendict = ["frozendict"]

--- a/setup.py
+++ b/setup.py
@@ -9,53 +9,55 @@ PyLD_ is a Python JSON-LD_ library.
 .. _JSON-LD: https://json-ld.org/
 """
 
-from distutils.core import setup
+import setuptools
 import os
 
 # get meta data
 about = {}
-with open(os.path.join(
-        os.path.dirname(__file__), 'lib', 'pyld', '__about__.py')) as fp:
+with open(os.path.join(os.path.dirname(__file__), "lib", "pyld", "__about__.py")) as fp:
     exec(fp.read(), about)
 
-with open('README.rst') as fp:
+with open("README.rst") as fp:
     long_description = fp.read()
 
-setup(
-    name='PyLD',
-    version=about['__version__'],
-    description='Python implementation of the JSON-LD API',
+setuptools.setup()
+
+"""setuptools.setup(
+    name="PyLD",
+    version=about["__version__"],
+    description="Python implementation of the JSON-LD API",
     long_description=long_description,
-    author='Digital Bazaar',
-    author_email='support@digitalbazaar.com',
-    url='https://github.com/digitalbazaar/pyld',
+    author="Digital Bazaar",
+    author_email="support@digitalbazaar.com",
+    url="https://github.com/digitalbazaar/pyld",
     packages=[
-        'c14n',
-        'pyld',
-        'pyld.documentloader',
+        "c14n",
+        "pyld",
+        "pyld.documentloader",
     ],
-    package_dir={'': 'lib'},
-    license='BSD 3-Clause license',
+    package_dir={"": "lib"},
+    license="BSD 3-Clause license",
     classifiers=[
-        'Development Status :: 4 - Beta',
-        'Environment :: Console',
-        'Environment :: Web Environment',
-        'Intended Audience :: Developers',
-        'License :: OSI Approved :: BSD License',
-        'Operating System :: OS Independent',
-        'Programming Language :: Python',
-        'Topic :: Internet',
-        'Topic :: Software Development :: Libraries',
+        "Development Status :: 4 - Beta",
+        "Environment :: Console",
+        "Environment :: Web Environment",
+        "Intended Audience :: Developers",
+        "License :: OSI Approved :: BSD License",
+        "Operating System :: OS Independent",
+        "Programming Language :: Python",
+        "Topic :: Internet",
+        "Topic :: Software Development :: Libraries",
     ],
     install_requires=[
-        'cachetools',
-        'frozendict',
-        'lxml',
+        "cachetools",
+        "frozendict",
+        "lxml",
     ],
     extras_require={
-        'requests': ['requests'],
-        'aiohttp': ['aiohttp'],
-        'cachetools': ['cachetools'],
-        'frozendict': ['frozendict'],
-    }
+        "requests": ["requests"],
+        "aiohttp": ["aiohttp"],
+        "cachetools": ["cachetools"],
+        "frozendict": ["frozendict"],
+    },
 )
+"""


### PR DESCRIPTION
Without it, more than one thread may try to pop the oldest key from the cache (causing an error), or other concurrency-based issues.